### PR TITLE
Normalize Player speed

### DIFF
--- a/src/object/Player.cpp
+++ b/src/object/Player.cpp
@@ -21,22 +21,22 @@ void Player::draw(MatrixStack& stack, GLuint program) const {
 
 void Player::update(float deltaTime) {
     Game& game = Game::getInstance();
+    float speed = 0.8F;
+
+    velocity = Vector2(0, 0);
+
     if (game.inputs[VK_W]) {
-        velocity.y = 0.8F;
+        velocity.y += speed;
     } else if (game.inputs[VK_S]) {
-        velocity.y = -0.8F;
-    } else {
-        velocity.y = 0.0F;
+        velocity.y -= speed;
     }
     if (game.inputs[VK_D]) {
-        velocity.x = 0.8F;
+        velocity.x += speed;
     } else if (game.inputs[VK_A]) {
-        velocity.x = -0.8F;
-    } else {
-        velocity.x = 0.0F;
+        velocity.x -= speed;
     }
 
-    velocity = velocity.normalized() * 0.8F;
+    velocity = velocity.normalized() * speed;
 
     Object::update(deltaTime);
 

--- a/src/object/Player.cpp
+++ b/src/object/Player.cpp
@@ -36,6 +36,8 @@ void Player::update(float deltaTime) {
         velocity.x = 0.0F;
     }
 
+    velocity = velocity.normalized() * 0.8F;
+
     Object::update(deltaTime);
 
     if (position.x - scale.x < -1.0F) {


### PR DESCRIPTION
This fixes the problem when moving diagonally, as it was going at a higher speed.

Changes: 

- Normalized the player movement speed to ensure consistent speed in all directions
- Refactored the speed handling code to improve readability